### PR TITLE
small style changes and a project filter

### DIFF
--- a/frontend/components/ProjectsDetails/index.tsx
+++ b/frontend/components/ProjectsDetails/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import styles from "./style.module.scss";
 import Link from "next/link";
 import { Project } from "../../interface/interface";
@@ -7,12 +8,17 @@ interface Props {
 }
 
 const ProjectsDetails = ({ data }: Props) => {
+	const [filter, setFilter] = useState("");
+
 	const elements = data
-		.map((project) => ({
-			...project,
-			updated_at_num: Date.parse(project.updated_at),
-		}))
-		.sort((a, b) => b.updated_at_num - a.updated_at_num)
+		.sort((a, b) => Date.parse(b.updated_at) - Date.parse(a.updated_at))
+		.filter((project) => {
+			return (
+				project.tools.toLocaleLowerCase().includes(filter) ||
+				project.dev.toLocaleLowerCase().includes(filter) ||
+				project.title.toLocaleLowerCase().includes(filter)
+			);
+		})
 		.map((project) => {
 			const dateStr = new Date(project.updated_at).toLocaleDateString();
 			return (
@@ -22,25 +28,37 @@ const ProjectsDetails = ({ data }: Props) => {
 							<a>{project.title}</a>
 						</Link>
 					</td>
-					<td>{project.dev}</td>
-					<td>{project.tools}</td>
-					<td>{dateStr}</td>
+					<td className={styles.devCol}>{project.dev}</td>
+					<td className={styles.toolsCol}>{project.tools}</td>
+					<td className={styles.dateCol}>
+						<span className={styles.date}>{dateStr}</span>
+					</td>
 				</tr>
 			);
 		});
 
 	return (
-		<table className={styles.table}>
-			<thead>
-				<tr>
-					<td>Name</td>
-					<td>Dev</td>
-					<td>Tools</td>
-					<td>Updated</td>
-				</tr>
-			</thead>
-			<tbody>{elements}</tbody>
-		</table>
+		<>
+			<div className={styles.filter}>
+				<input
+					type="text"
+					value={filter}
+					onChange={(event) => setFilter(event.target.value)}
+					placeholder="Filter"
+				/>
+			</div>
+			<table className={styles.table}>
+				<thead>
+					<tr>
+						<td>Name</td>
+						<td className={styles.devCol}>Dev</td>
+						<td className={styles.toolsCol}>Tools</td>
+						<td className={styles.dateCol}>Updated</td>
+					</tr>
+				</thead>
+				<tbody>{elements}</tbody>
+			</table>
+		</>
 	);
 };
 

--- a/frontend/components/ProjectsDetails/style.module.scss
+++ b/frontend/components/ProjectsDetails/style.module.scss
@@ -20,3 +20,47 @@
 		padding: 0.3em;
 	}
 }
+
+.date {
+	white-space: nowrap;
+}
+
+.devCol {
+	display: none;
+
+	@media screen and (min-width: 850px) {
+		display: table-cell;
+	}
+}
+
+.toolsCol {
+	display: none;
+
+	@media screen and (min-width: 480px) {
+		display: table-cell;
+	}
+}
+
+.dateCol {
+	display: none;
+
+	@media screen and (min-width: 600px) {
+		display: table-cell;
+	}
+}
+
+.filter {
+	display: flex;
+	justify-content: center;
+	margin: 0 0 1.4em;
+
+	input {
+		display: block;
+		width: 100%;
+		max-width: 200px;
+		font-size: 1rem;
+		background: #404040;
+		border: 1px solid #737373;
+		color: inherit;
+	}
+}


### PR DESCRIPTION
Made only the project title visible on mobile and more columns visible as screen gets wider. I also added a filter box so you can search for a specific tool/project name/etc. This should also fix the dates dropping onto new lines.